### PR TITLE
Update unity test coverage comment

### DIFF
--- a/.github/workflows/unity-test-coverage.yaml
+++ b/.github/workflows/unity-test-coverage.yaml
@@ -47,6 +47,7 @@ jobs:
           customParameters: -enableCodeCoverage -coverageOptions "useProjectSettings"
 
       - name: Form comment msg
+        if: github.event_name == 'pull_request'
         run: |
           echo "### Unity Test Coverage output" > comment.md
           echo "" >> comment.md  
@@ -57,6 +58,7 @@ jobs:
           cat "${{ steps.unity-test.outputs.coveragePath }}/Report/Summary.md" >> comment.md
 
       - name: Find Comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3
         id: fc
         with:
@@ -65,6 +67,7 @@ jobs:
           body-includes: Unity Test Coverage output
   
       - name: Create or update comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
Conditionally run Peter Evans comment steps only for pull requests to prevent errors on push events.

The `peter-evans/find-comment` and `peter-evans/create-or-update-comment` actions, along with the "Form comment msg" step, rely on `github.event.pull_request.number` which is only available during `pull_request` events. Adding an `if` condition ensures these steps are skipped when the workflow is triggered by a `push` or `workflow_call` event, avoiding runtime errors and unnecessary execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-f905b5ea-4bbd-4c1a-8308-d20e81ad1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f905b5ea-4bbd-4c1a-8308-d20e81ad1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

