### PR TITLE
Configure git author identity for workflow

### DIFF
--- a/.github/workflows/patch-versions.yaml
+++ b/.github/workflows/patch-versions.yaml
@@ -60,8 +60,8 @@ jobs:
         id: commit
         if: ${{ steps.check_update.outputs.changed == '1' }}
         run: |
-          git config --local user.email "${{ secrets.ADMIN_EMAIL }}"
-          git config --local user.name "${{ secrets.ADMIN_NAME }}"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git commit -m "${{ steps.configure.outputs.git-tag }}" -a
           echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Configure Git author identity in `patch-versions.yaml` to use the GitHub Actions bot to prevent workflow failures.

The previous configuration relied on `secrets.ADMIN_EMAIL` and `secrets.ADMIN_NAME`, which were often empty, causing Git to fail with "Author identity unknown" errors. Using the `github-actions[bot]` identity provides a reliable and standard solution for automated commits.

---
<a href="https://cursor.com/background-agent?bcId=bc-68d24dcf-a2af-488d-9d31-ca63c56c3dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68d24dcf-a2af-488d-9d31-ca63c56c3dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

